### PR TITLE
Use monotonic clock to prevent false timeouts with Timecop

### DIFF
--- a/lib/rspec_time_guard.rb
+++ b/lib/rspec_time_guard.rb
@@ -18,7 +18,7 @@ module RspecTimeGuard
       @mutex.synchronize do
         @active_tests[example.object_id] = {
           example: example,
-          start_time: Time.now,
+          start_time: Process.clock_gettime(Process::CLOCK_MONOTONIC),
           timeout: timeout,
           thread_id: thread.object_id,
           warned: false
@@ -52,7 +52,7 @@ module RspecTimeGuard
     end
 
     def check_for_timeouts
-      now = Time.now
+      now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       timed_out_examples = []
 
       @mutex.synchronize do


### PR DESCRIPTION
# Description

`Time.now` is used in `register_test` and `check_for_timeouts` to measure how long a test has been running. The problem is that `Time.now` is monkey-patched by [Timecop](https://github.com/travisjeffery/timecop) (and similar gems like `travel_to` in Rails). When a test calls `Timecop.travel(3.days)`, the monitor thread suddenly sees 259200+ seconds of elapsed time and kills the test immediately — even though only a few real seconds have passed.

`Process.clock_gettime(Process::CLOCK_MONOTONIC)` is immune to `Time.now` manipulation, so it always reflects actual wall-clock elapsed time.

**Changes:**
- Replace `Time.now` with `Process.clock_gettime(Process::CLOCK_MONOTONIC)` in `register_test` (start time) and `check_for_timeouts` (current time)
