### PR TITLE
Fix error in around hook rescue clause

### DIFF
--- a/lib/rspec_time_guard.rb
+++ b/lib/rspec_time_guard.rb
@@ -125,9 +125,6 @@ module RspecTimeGuard
 
           begin
             example.run
-          rescue RspecTimeGuard::TimeLimitExceededError => e
-            # NOTE: This changes the example's status to failed and records our error
-            example.exception = e
           ensure
             RspecTimeGuard.monitor.unregister_test(example)
           end


### PR DESCRIPTION
### Problem

Every timeout error:
```
     1.1) Failure/Error: analysis.wait_until_chill_dialog_invisible
          
          RspecTimeGuard::TimeLimitExceededError:
            Test 'such and such' timed out after 120.0s (took 120.19s)
          
          # ./spec/system/etcetcetc_spec.rb:313:in `block in etc_will_be_enabled_and_available'
          # ./spec/spec_helper.rb:53:in `block (2 levels) in <top (required)>'
```

is followed immediately by this error:

```
     1.2) Failure/Error: example.run
          
          NoMethodError:
            undefined method `exception=' for an instance of RSpec::Core::Example::Procsy
```          

### Solution

There's no need to rescue RSpecTimeGuard::TimeLimitExceededError, because rspec's `RSpec::Core::Example#with_around_example_hooks` already handles this.

Additionally, this was simply _wrong_.  There is no `example.exception=` method.  The method is `#set_exception`.  Either way, we can just let rspec handle it.